### PR TITLE
Testnet CCTP contracts

### DIFF
--- a/cctp/cctp_config.test.json
+++ b/cctp/cctp_config.test.json
@@ -1,0 +1,6 @@
+{
+    "routerAddresses": {
+        "avalanche": "0x6ce27f0b66bb6a3e791def559dcaa77a1c86a9fb",
+        "ethereum": "0x930daa19e1d24d4e027cc0c469c1428282cf839f"
+    }
+}


### PR DESCRIPTION
The Goerli and Fuji `AvaEthUSDCRouter` contract addresses, to be pulled in by various UIs.