### PR TITLE
Add mainnet TokenRouter contract addresses

### DIFF
--- a/cctp/cctp_config.json
+++ b/cctp/cctp_config.json
@@ -1,6 +1,6 @@
 {
     "routerAddresses": {
-        "avalanche": ""0x88abde178ace494d0000aa61f6a04e5f74a3e87c",
+        "avalanche": "0x88abde178ace494d0000aa61f6a04e5f74a3e87c",
         "ethereum": "0x88abde178ace494d0000aa61f6a04e5f74a3e87c"
     }
 }

--- a/cctp/cctp_config.mainnet.json
+++ b/cctp/cctp_config.mainnet.json
@@ -1,0 +1,6 @@
+{
+    "routerAddresses": {
+        "avalanche": ""0x88abde178ace494d0000aa61f6a04e5f74a3e87c",
+        "ethereum": "0x88abde178ace494d0000aa61f6a04e5f74a3e87c"
+    }
+}


### PR DESCRIPTION
mainnet TokenRouter contract addresses:
Ethereum: [0x88abde178ace494d0000aa61f6a04e5f74a3e87c](https://etherscan.io/address/0x88abde178ace494d0000aa61f6a04e5f74a3e87c)
Avalanche: [0x88abde178ace494d0000aa61f6a04e5f74a3e87c](https://snowtrace.io/address/0x88abde178ace494d0000aa61f6a04e5f74a3e87c)