### PR TITLE
Update dev contract address

### DIFF
--- a/cctp/cctp_config.test.json
+++ b/cctp/cctp_config.test.json
@@ -1,6 +1,6 @@
 {
     "routerAddresses": {
-        "avalanche": "0x4998e977c58280922379624a1a8664a9fb2cae16",
-        "ethereum": "0x1fb05f4f86935212428e810c6637569b5bd3283b"
+        "avalanche": "0x3002ad2c7c43f191afd39d6fffdbf8f7e2b13da1",
+        "ethereum": "0x3776ed16d37390a132d47e1137bda83ddf6090c4"
     }
 }


### PR DESCRIPTION
The TokenRouter contract is updated in this https://github.com/ava-labs/cctp-integration/pull/90.
The new version of contract is deployed to

Goerli: [0x3776ED16d37390a132d47E1137BdA83DDf6090c4](https://goerli.etherscan.io/address/0x3776ed16d37390a132d47e1137bda83ddf6090c4)
Fuji: [0x3002ad2c7c43f191AFd39d6fffdBF8f7E2b13DA1](https://testnet.snowtrace.io/address/0x3002ad2c7c43f191afd39d6fffdbf8f7e2b13da1)
Use the new contract address in dev.