### PR TITLE
Update mainnet contract address

### DIFF
--- a/cctp/cctp_config.json
+++ b/cctp/cctp_config.json
@@ -1,6 +1,6 @@
 {
     "routerAddresses": {
-        "avalanche": "0x88abde178ace494d0000aa61f6a04e5f74a3e87c",
-        "ethereum": "0x88abde178ace494d0000aa61f6a04e5f74a3e87c"
+        "avalanche": "0xD835dbD135AD8a27214ecdEE79E7a41337865648",
+        "ethereum": "0xD835dbD135AD8a27214ecdEE79E7a41337865648"
     }
 }


### PR DESCRIPTION
The TokenRouter contract is updated in this https://github.com/ava-labs/cctp-integration/pull/90.
The new version of contract is deployed to

ETH mainnet: [0xD835dbD135AD8a27214ecdEE79E7a41337865648](https://etherscan.io/address/0xd835dbd135ad8a27214ecdee79e7a41337865648)
Avalanche: [0xD835dbD135AD8a27214ecdEE79E7a41337865648](https://snowtrace.io/address/0xd835dbd135ad8a27214ecdee79e7a41337865648)