### PR TITLE
feat: add cctp min confirmations

### DIFF
--- a/cctp/cctp_config.json
+++ b/cctp/cctp_config.json
@@ -4,6 +4,7 @@
         "domain": 0,
         "tokenRouterAddress": "0xD835dbD135AD8a27214ecdEE79E7a41337865648",
         "messageTransmitterAddress": "0x0a992d191deec32afe36203ad87d7d289a738f81",
+        "minimumConfirmations": 65,
         "tokens": [
             {
                 "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18,6 +19,7 @@
         "domain": 1,
         "tokenRouterAddress": "0xD835dbD135AD8a27214ecdEE79E7a41337865648",
         "messageTransmitterAddress": "0x8186359af5f57fbb40c6b14a588d2a59c0c29880",
+        "minimumConfirmations": 1,
         "tokens": [
             {
                 "address": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",

--- a/cctp/cctp_config.test.json
+++ b/cctp/cctp_config.test.json
@@ -4,6 +4,7 @@
         "domain": 0,
         "tokenRouterAddress": "0x3776ed16d37390a132d47e1137bda83ddf6090c4",
         "messageTransmitterAddress": "0x26413e8157cd32011e726065a5462e97dd4d03d9",
+        "minimumConfirmations": 5,
         "tokens": [
             {
                 "address": "0x07865c6e87b9f70255377e024ace6630c1eaa37f",
@@ -18,6 +19,7 @@
         "domain": 1,
         "tokenRouterAddress": "0x3002ad2c7c43f191afd39d6fffdbf8f7e2b13da1",
         "messageTransmitterAddress": "0xa9fb1b3009dcb79e2fe346c16a604b8fa8ae0a79",
+        "minimumConfirmations": 1,
         "tokens": [
             {
                 "address": "0x5425890298aed601595a70ab815c96711a31bc65",


### PR DESCRIPTION
Adds `minimumConfirmations` to the CCTP configs, based on https://developers.circle.com/stablecoins/docs/required-block-confirmations